### PR TITLE
add grpc path for new ingress 1.18

### DIFF
--- a/docker/nginx/conf.d/grpc/include.auto_od.template
+++ b/docker/nginx/conf.d/grpc/include.auto_od.template
@@ -1,3 +1,7 @@
 location /hydrosphere.auto_od. {
   grpc_pass grpc://${AUTO_OD_HOST}:${AUTO_OD_GRPC_PORT};
 }
+
+location /grpc/hydrosphere.auto_od. {
+  grpc_pass grpc://${AUTO_OD_HOST}:${AUTO_OD_GRPC_PORT};
+}

--- a/docker/nginx/conf.d/grpc/include.gateway.template
+++ b/docker/nginx/conf.d/grpc/include.gateway.template
@@ -7,3 +7,13 @@ location /hydrosphere.serving.gateway. {
   grpc_pass grpc://$GATEWAY_HOST:$GATEWAY_GRPC_PORT;
   #grpc_pass grpc://gateway_grpc;
 }
+
+location /grpc/tensorflow.serving. {
+  grpc_pass grpc://$GATEWAY_HOST:$GATEWAY_GRPC_PORT;
+  #grpc_pass grpc://gateway_grpc;
+}
+
+location /grpc/hydrosphere.serving.gateway. {
+  grpc_pass grpc://$GATEWAY_HOST:$GATEWAY_GRPC_PORT;
+  #grpc_pass grpc://gateway_grpc;
+}

--- a/docker/nginx/conf.d/grpc/include.manager.template
+++ b/docker/nginx/conf.d/grpc/include.manager.template
@@ -5,3 +5,11 @@ location /hydrosphere.manager. {
 location /hydrosphere.discovery. {
   grpc_pass grpc://${MANAGER_HOST}:${MANAGER_GRPC_PORT};
 }
+
+location /grpc/hydrosphere.manager. {
+  grpc_pass grpc://${MANAGER_HOST}:${MANAGER_GRPC_PORT};
+}
+
+location /grpc/hydrosphere.discovery. {
+  grpc_pass grpc://${MANAGER_HOST}:${MANAGER_GRPC_PORT};
+}

--- a/docker/nginx/conf.d/grpc/include.monitoring.template
+++ b/docker/nginx/conf.d/grpc/include.monitoring.template
@@ -1,3 +1,7 @@
 location /hydrosphere.monitoring. {
   grpc_pass grpc://${MONITORING_HOST}:${MONITORING_GRPC_PORT};
 }
+
+location /grpc/hydrosphere.monitoring. {
+  grpc_pass grpc://${MONITORING_HOST}:${MONITORING_GRPC_PORT};
+}

--- a/docker/nginx/conf.d/grpc/include.visualization.template
+++ b/docker/nginx/conf.d/grpc/include.visualization.template
@@ -1,3 +1,7 @@
 location /hydrosphere.visualization. {
   grpc_pass grpc://${VISUALIZATION_HOST}:${VISUALIZATION_GRPC_PORT};
 }
+
+location /grpc/hydrosphere.visualization. {
+  grpc_pass grpc://${VISUALIZATION_HOST}:${VISUALIZATION_GRPC_PORT};
+}


### PR DESCRIPTION
in the new ingress specification for Kubernetes above 1.18, you need to specify pathType and in order for the prefix type to work, additional locations were added. The old ones are left for compatibility