### PR TITLE
Model version's service availability check

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -19,6 +19,7 @@ import {
   ModelVersionsEffects,
   ServablesEffects,
   DeploymentConfigsEffects,
+  ServiceStatusesEffects
 } from './store/effects';
 
 @NgModule({
@@ -32,6 +33,7 @@ import {
       ModelVersionsEffects,
       ServablesEffects,
       DeploymentConfigsEffects,
+      ServiceStatusesEffects
     ]),
     StoreRouterConnectingModule.forRoot({
       stateKey: 'router',

--- a/src/app/core/data/services/service-status.service.ts
+++ b/src/app/core/data/services/service-status.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { HttpService } from '@app/core/data/services/http.service';
+import {
+  createServiceSupportOnFailure,
+  ModelVersion,
+  ModelVersionServicesStatus,
+  ServiceSupported,
+} from '@app/core/data/types';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+const enum ServicesEndpoints {
+  stat = 'stat/support',
+  visualization = 'visualization/supported',
+}
+@Injectable({
+  providedIn: 'root'
+})
+export class ServiceStatusService {
+
+  constructor(private http: HttpService) {}
+
+  loadSupported(modelVersion: ModelVersion): Observable<ModelVersionServicesStatus> {
+    const toRequest = endpoint =>
+      this.http
+        .get<ServiceSupported>(endpoint, { params: { model_version_id: `${modelVersion.id}` } })
+        .pipe(
+          catchError(err => {
+            return of(createServiceSupportOnFailure(err))
+          })
+        )
+
+    return forkJoin({
+      stat: toRequest(ServicesEndpoints.stat),
+      visualization: toRequest(ServicesEndpoints.visualization),
+    })
+  }
+}

--- a/src/app/core/data/types/index.ts
+++ b/src/app/core/data/types/index.ts
@@ -11,3 +11,4 @@ export * from './servable';
 export * from './service-status';
 export * from './signature';
 export * from './tensor-proto';
+export * from './model-version-service-status';

--- a/src/app/core/data/types/model-version-service-status.ts
+++ b/src/app/core/data/types/model-version-service-status.ts
@@ -1,0 +1,26 @@
+import { of } from 'rxjs';
+
+export interface ServiceSupported {
+  supported: boolean;
+  message: string;
+  description?: string;
+}
+
+export interface ModelVersionServicesStatus {
+  [serviceName: string]: ServiceSupported
+}
+
+export interface ModelVersionServiceStatusesEntity {
+  id: number,
+  statuses: ModelVersionServicesStatus
+}
+
+export function createServiceSupportOnFailure(error: string): ServiceSupported {
+  const is501Error = /501/i.test(error);
+  if (is501Error) {
+    return { supported: false, message: 'Closed for OSS' };
+  } else {
+    const errMsg = error || 'Something went wrong';
+    return { supported: false, message: errMsg };
+  }
+}

--- a/src/app/core/facades/service-statuses.facade.ts
+++ b/src/app/core/facades/service-statuses.facade.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { select, Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+
+import { ModelVersion, ModelVersionServiceStatusesEntity } from '@app/core/data/types';
+import { HydroServingState } from '@app/core/store/states/root.state';
+import { Get } from '@app/core/store/actions/service-statuses.actions';
+import { selectServiceStatusesById } from '@app/core/store/selectors/service-statuses.selectors';
+
+@Injectable({ providedIn: 'root' })
+export class ServiceStatusesFacade {
+  constructor(private readonly store: Store<HydroServingState>) {}
+
+  loadAll(modelVersion: ModelVersion): void {
+    this.store.dispatch(Get({ payload: modelVersion }));
+  }
+
+  selectServiceStatusesById(id: number): Observable<ModelVersionServiceStatusesEntity> {
+    return this.store.pipe(select(selectServiceStatusesById(id)))
+  }
+}

--- a/src/app/core/store/actions/service-statuses.actions.ts
+++ b/src/app/core/store/actions/service-statuses.actions.ts
@@ -1,0 +1,16 @@
+import { createAction, props } from '@ngrx/store';
+import { ModelVersion, ModelVersionServiceStatusesEntity } from '../../data/types';
+
+export const Get = createAction(
+  '[ServiceStatus] Get services statuses',
+  props<{ payload: ModelVersion }>()
+);
+export const GetSuccess = createAction(
+  '[ServiceStatus] Get services statuses with success',
+  props<{ payload: ModelVersionServiceStatusesEntity }>()
+);
+export const GetFail = createAction(
+  '[ServiceStatus] Get services statuses with fail',
+  props<{ error: string }>()
+);
+

--- a/src/app/core/store/effects/index.ts
+++ b/src/app/core/store/effects/index.ts
@@ -3,3 +3,4 @@ export * from './models.effects';
 export * from './model-versions.effects';
 export * from './servables.effects';
 export * from './deployment-configs.effects';
+export * from './service-statuses.effects';

--- a/src/app/core/store/effects/service-statuses.effects.ts
+++ b/src/app/core/store/effects/service-statuses.effects.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { Get, GetFail, GetSuccess } from '@app/core/store/actions/service-statuses.actions';
+import { ServiceStatusService } from '@app/core/data/services/service-status.service';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+
+@Injectable()
+export class ServiceStatusesEffects {
+  getServiceStatuses$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(Get),
+      switchMap(
+        action => {
+          return this.serviceStatusService.loadSupported(action.payload).pipe(
+            map(res => {
+                const payload = {
+                  id: action.payload.id,
+                  statuses: res
+                }
+                return GetSuccess({ payload })
+              },
+              catchError(error => {
+                return of(GetFail({ error }))
+              })
+            )
+          )
+        }
+      )
+    )
+  )
+
+  constructor(
+    private actions$: Actions,
+    private serviceStatusService: ServiceStatusService,
+  ) {}
+}

--- a/src/app/core/store/reducers/root.reducer.ts
+++ b/src/app/core/store/reducers/root.reducer.ts
@@ -6,6 +6,7 @@ import * as fromModels from './models.reducer';
 import * as fromModelVersions from './model-version.reducer';
 import * as fromServables from './servables.reducer';
 import * as fromDeploymentConfigs from './deployment-configs.reducer';
+import * as fromServiceStatuses from './service-statuses.reducer'
 
 import { HydroServingState } from '../states/root.state';
 
@@ -16,4 +17,5 @@ export const reducers: ActionReducerMap<HydroServingState> = {
   models: fromModels.reducer,
   servables: fromServables.reducer,
   deploymentConfigs: fromDeploymentConfigs.reducer,
+  serviceStatuses: fromServiceStatuses.reducer
 };

--- a/src/app/core/store/reducers/service-statuses.reducer.ts
+++ b/src/app/core/store/reducers/service-statuses.reducer.ts
@@ -1,0 +1,16 @@
+import { createReducer, Action, on } from '@ngrx/store';
+import { Get, GetFail, GetSuccess } from '@app/core/store/actions/service-statuses.actions';
+import { adapter, initialState, State } from '../states/service-statuses.state';
+
+const serviceStatusesReducer = createReducer(
+  initialState,
+  on(Get, state => state),
+  on(GetSuccess, (state, { payload }) =>
+    adapter.addOne(payload, state)
+  ),
+  on(GetFail, state => state)
+);
+
+export function reducer(state: State, action: Action): State {
+  return serviceStatusesReducer(state, action);
+}

--- a/src/app/core/store/reducers/service-statuses.reducer.ts
+++ b/src/app/core/store/reducers/service-statuses.reducer.ts
@@ -4,11 +4,9 @@ import { adapter, initialState, State } from '../states/service-statuses.state';
 
 const serviceStatusesReducer = createReducer(
   initialState,
-  on(Get, state => state),
   on(GetSuccess, (state, { payload }) =>
     adapter.addOne(payload, state)
-  ),
-  on(GetFail, state => state)
+  )
 );
 
 export function reducer(state: State, action: Action): State {

--- a/src/app/core/store/selectors/service-statuses.selectors.ts
+++ b/src/app/core/store/selectors/service-statuses.selectors.ts
@@ -1,0 +1,10 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { State, adapter } from '../states/service-statuses.state';
+
+const state = createFeatureSelector<State>('serviceStatuses');
+const { selectEntities } = adapter.getSelectors();
+
+export const allStatuses = createSelector(state, selectEntities)
+export const selectServiceStatusesById = (id: number) =>
+  createSelector(allStatuses, entities => entities[id]
+);

--- a/src/app/core/store/states/root.state.ts
+++ b/src/app/core/store/states/root.state.ts
@@ -6,6 +6,7 @@ import * as fromModels from './models.state';
 import * as fromModelVersions from './model-versions.state';
 import * as fromServables from './servables.state';
 import * as fromDeploymentConfigs from './deployment-configs.state';
+import * as fromServiceStatuses from './service-statuses.state'
 
 export interface HydroServingState {
   router: fromRouter.RouterReducerState<RouterStateUrl>;
@@ -14,6 +15,7 @@ export interface HydroServingState {
   modelVersions: fromModelVersions.State;
   servables: fromServables.State;
   deploymentConfigs: fromDeploymentConfigs.State;
+  serviceStatuses: fromServiceStatuses.State
 }
 
 export const initialState: HydroServingState = {
@@ -30,4 +32,5 @@ export const initialState: HydroServingState = {
   modelVersions: fromModelVersions.initialState,
   servables: fromServables.initialState,
   deploymentConfigs: fromDeploymentConfigs.initialState,
+  serviceStatuses: fromServiceStatuses.initialState
 };

--- a/src/app/core/store/states/service-statuses.state.ts
+++ b/src/app/core/store/states/service-statuses.state.ts
@@ -1,0 +1,13 @@
+import { createEntityAdapter, EntityAdapter, EntityState } from '@ngrx/entity';
+import { ModelVersionServiceStatusesEntity } from '@app/core/data/types';
+
+export interface State extends EntityState<ModelVersionServiceStatusesEntity> {}
+
+export const adapter: EntityAdapter<ModelVersionServiceStatusesEntity> = createEntityAdapter<
+  ModelVersionServiceStatusesEntity
+>();
+
+export const initialState: State = {
+  ids: [],
+  entities: {}
+};

--- a/src/app/modules/applications/applications.module.ts
+++ b/src/app/modules/applications/applications.module.ts
@@ -20,10 +20,10 @@ import { ApplicationDetailsComponent } from './containers/application-details/ap
     UpdateModelVersionDirective,
     ApplicationFormComponent,
     ModelVariantFormComponent,
-    KafkaFormComponent,
+    KafkaFormComponent
   ],
   entryComponents: [],
   providers: [],
-  exports: [ApplicationFormComponent],
+  exports: [ApplicationFormComponent, ApplicationDetailsComponent],
 })
 export class ApplicationsModule {}

--- a/src/app/modules/applications/applications.module.ts
+++ b/src/app/modules/applications/applications.module.ts
@@ -24,6 +24,6 @@ import { ApplicationDetailsComponent } from './containers/application-details/ap
   ],
   entryComponents: [],
   providers: [],
-  exports: [ApplicationFormComponent, ApplicationDetailsComponent],
+  exports: [ApplicationFormComponent],
 })
 export class ApplicationsModule {}

--- a/src/app/modules/applications/containers/application-details/application-details.component.html
+++ b/src/app/modules/applications/containers/application-details/application-details.component.html
@@ -148,6 +148,7 @@
         monitoring
       </div>
       <div
+        [ngClass]="{'menu__item--disabled': !menu.statuses.statuses.visualization.supported}"
         class="menu__item"
         [routerLink]="[
           '/models',
@@ -159,6 +160,7 @@
         data projection
       </div>
       <div
+        [ngClass]="{'menu__item--disabled': !menu.statuses.statuses.stat.supported}"
         class="menu__item"
         [routerLink]="[
           '/models',
@@ -172,3 +174,4 @@
     </ng-container>
   </div>
 </ng-container>
+

--- a/src/app/modules/applications/containers/application-details/application-details.component.html
+++ b/src/app/modules/applications/containers/application-details/application-details.component.html
@@ -148,7 +148,7 @@
         monitoring
       </div>
       <div
-        [ngClass]="{'menu__item--disabled': !menu.statuses.statuses.visualization.supported}"
+        [ngClass]="{'menu__item--disabled': !menu.statuses?.statuses?.visualization?.supported}"
         class="menu__item"
         [routerLink]="[
           '/models',
@@ -160,7 +160,7 @@
         data projection
       </div>
       <div
-        [ngClass]="{'menu__item--disabled': !menu.statuses.statuses.stat.supported}"
+        [ngClass]="{'menu__item--disabled': !menu.statuses?.statuses?.stat?.supported}"
         class="menu__item"
         [routerLink]="[
           '/models',

--- a/src/app/modules/applications/containers/application-details/application-details.component.scss
+++ b/src/app/modules/applications/containers/application-details/application-details.component.scss
@@ -236,6 +236,9 @@
     }
   }
 }
+
+@import 'variables';
+
 .menu {
   position: absolute;
   border: 1px $neutral-color-700 solid;
@@ -257,6 +260,10 @@
     &--accent {
       background: $supportive-color-green-100;
       color: $supportive-color-green-700;
+    }
+    &--disabled {
+      pointer-events: none;
+      opacity: 0.5;
     }
   }
   &--showed {

--- a/src/app/modules/model-version/containers/model-version-services/model-version-services.component.html
+++ b/src/app/modules/model-version/containers/model-version-services/model-version-services.component.html
@@ -17,26 +17,26 @@
 
     <ng-container
       *ngTemplateOutlet="
-        (serviceStatuses$ | async)?.statuses.visualization?.supported
+        (serviceStatuses$ | async)?.statuses?.visualization?.supported
           ? visualizationTile
           : notSupported;
         context: {
           name: 'Data projection',
           iconName: 'data_projection',
-          message: (serviceStatuses$ | async)?.statuses.visualization?.message
+          message: (serviceStatuses$ | async)?.statuses?.visualization?.message
         }
       "
     >
     </ng-container>
     <ng-container
       *ngTemplateOutlet="
-        (serviceStatuses$ | async)?.statuses.stat?.supported
+        (serviceStatuses$ | async)?.statuses?.stat?.supported
           ? monitoringTile
           : notSupported;
         context: {
           name: 'Drift Report',
           iconName: 'drift_report',
-          message: (serviceStatuses$ | async)?.statuses.stat?.description
+          message: (serviceStatuses$ | async)?.statuses?.stat?.description
         }
       "
     >

--- a/src/app/modules/model-version/containers/model-version-services/model-version-services.component.html
+++ b/src/app/modules/model-version/containers/model-version-services/model-version-services.component.html
@@ -17,26 +17,26 @@
 
     <ng-container
       *ngTemplateOutlet="
-        (serviceSupported$ | async)?.visualization?.supported
+        (serviceStatuses$ | async)?.statuses.visualization?.supported
           ? visualizationTile
           : notSupported;
         context: {
           name: 'Data projection',
           iconName: 'data_projection',
-          message: (serviceSupported$ | async)?.visualization?.message
+          message: (serviceStatuses$ | async)?.statuses.visualization?.message
         }
       "
     >
     </ng-container>
     <ng-container
       *ngTemplateOutlet="
-        (serviceSupported$ | async)?.stat?.supported
+        (serviceStatuses$ | async)?.statuses.stat?.supported
           ? monitoringTile
           : notSupported;
         context: {
           name: 'Drift Report',
           iconName: 'drift_report',
-          message: (serviceSupported$ | async)?.stat?.description
+          message: (serviceStatuses$ | async)?.statuses.stat?.description
         }
       "
     >

--- a/src/app/modules/model-version/containers/model-version-services/model-version-services.component.ts
+++ b/src/app/modules/model-version/containers/model-version-services/model-version-services.component.ts
@@ -1,13 +1,9 @@
 import { Component, OnInit, Input } from '@angular/core';
 
 import { Observable } from 'rxjs';
-import { take } from 'rxjs/internal/operators';
-import { select, Store } from '@ngrx/store';
 
 import { ModelVersion, ModelVersionServiceStatusesEntity } from '@app/core/data/types';
-import { HydroServingState } from '@app/core/store/states/root.state';
-import { Get } from '@app/core/store/actions/service-statuses.actions';
-import { selectServiceStatusesById } from '@app/core/store/selectors/service-statuses.selectors';
+import { ServiceStatusesFacade } from '@app/core/facades/service-statuses.facade';
 
 @Component({
   selector: 'hs-model-version-services',
@@ -19,16 +15,14 @@ export class ModelVersionServicesComponent implements OnInit {
 
   serviceStatuses$: Observable<ModelVersionServiceStatusesEntity>;
 
-  constructor(private readonly store: Store<HydroServingState>) {}
+  constructor(private readonly serviceFacade: ServiceStatusesFacade) {}
 
   serviceStatusesById$(id: number): Observable<ModelVersionServiceStatusesEntity> {
-    return this.store.pipe(
-      select(selectServiceStatusesById(id))
-    );
+    return this.serviceFacade.selectServiceStatusesById(id);
   }
 
   ngOnInit() {
-    this.store.dispatch(Get({ payload: this.modelVersion }));
+    this.serviceFacade.loadAll(this.modelVersion);
     this.serviceStatuses$ = this.serviceStatusesById$(this.modelVersion.id);
   }
 }

--- a/src/app/modules/model-version/containers/model-version-services/model-version-services.component.ts
+++ b/src/app/modules/model-version/containers/model-version-services/model-version-services.component.ts
@@ -1,26 +1,34 @@
 import { Component, OnInit, Input } from '@angular/core';
-import {
-  ServicesSupportService,
-  ServiceSupported,
-} from '../../services-support.service';
+
 import { Observable } from 'rxjs';
-import { ModelVersion } from '@app/core/data/types';
+import { take } from 'rxjs/internal/operators';
+import { select, Store } from '@ngrx/store';
+
+import { ModelVersion, ModelVersionServiceStatusesEntity } from '@app/core/data/types';
+import { HydroServingState } from '@app/core/store/states/root.state';
+import { Get } from '@app/core/store/actions/service-statuses.actions';
+import { selectServiceStatusesById } from '@app/core/store/selectors/service-statuses.selectors';
 
 @Component({
   selector: 'hs-model-version-services',
   templateUrl: './model-version-services.component.html',
-  styleUrls: ['./model-version-services.component.scss'],
-  providers: [ServicesSupportService],
+  styleUrls: ['./model-version-services.component.scss']
 })
 export class ModelVersionServicesComponent implements OnInit {
   @Input() modelVersion: ModelVersion;
 
-  serviceSupported$: Observable<{ [serviceName: string]: ServiceSupported }>;
+  serviceStatuses$: Observable<ModelVersionServiceStatusesEntity>;
 
-  constructor(private readonly servicesSupport: ServicesSupportService) {}
+  constructor(private readonly store: Store<HydroServingState>) {}
+
+  serviceStatusesById$(id: number): Observable<ModelVersionServiceStatusesEntity> {
+    return this.store.pipe(
+      select(selectServiceStatusesById(id))
+    );
+  }
 
   ngOnInit() {
-    this.serviceSupported$ = this.servicesSupport.getServiceSupported();
-    this.servicesSupport.loadSupported(this.modelVersion);
+    this.store.dispatch(Get({ payload: this.modelVersion }));
+    this.serviceStatuses$ = this.serviceStatusesById$(this.modelVersion.id);
   }
 }

--- a/src/app/modules/model-version/model-version.module.ts
+++ b/src/app/modules/model-version/model-version.module.ts
@@ -15,7 +15,6 @@ import {
   ModelVersionServicesComponent,
   ModelVersionDetailsComponent,
 } from './containers';
-import { ApplicationsModule } from '@app/modules/applications/applications.module';
 
 @NgModule({
   entryComponents: [ModelVersionLogComponent],
@@ -27,6 +26,6 @@ import { ApplicationsModule } from '@app/modules/applications/applications.modul
     SignaturesComponent,
     ModelVersionLogComponent,
   ],
-  imports: [SharedModule, ModelVersionRoutingModule, ServablesModule, ApplicationsModule],
+  imports: [SharedModule, ModelVersionRoutingModule, ServablesModule],
 })
 export class ModelVersionModule {}

--- a/src/app/modules/model-version/model-version.module.ts
+++ b/src/app/modules/model-version/model-version.module.ts
@@ -15,6 +15,7 @@ import {
   ModelVersionServicesComponent,
   ModelVersionDetailsComponent,
 } from './containers';
+import { ApplicationsModule } from '@app/modules/applications/applications.module';
 
 @NgModule({
   entryComponents: [ModelVersionLogComponent],
@@ -26,6 +27,6 @@ import {
     SignaturesComponent,
     ModelVersionLogComponent,
   ],
-  imports: [SharedModule, ModelVersionRoutingModule, ServablesModule],
+  imports: [SharedModule, ModelVersionRoutingModule, ServablesModule, ApplicationsModule],
 })
 export class ModelVersionModule {}

--- a/src/app/modules/model-version/services-support.service.ts
+++ b/src/app/modules/model-version/services-support.service.ts
@@ -2,17 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpService } from '@app/core/data/services/http.service';
 import { Observable, of, forkJoin, BehaviorSubject } from 'rxjs';
 import { catchError, shareReplay, distinctUntilChanged } from 'rxjs/operators';
-import { ModelVersion } from '@app/core/data/types';
-
-export interface ServiceSupported {
-  supported: boolean;
-  message: string;
-  description?: string;
-}
-
-export interface ModelVersionServicesStatus {
-  [serviceName: string]: ServiceSupported
-}
+import { ModelVersion, ModelVersionServicesStatus, ServiceSupported } from '@app/core/data/types';
 
 const enum ServicesEndpoints {
   stat = 'stat/support',
@@ -36,7 +26,6 @@ export class ServicesSupportService {
   }
 
   loadSupported(modelVersion: ModelVersion): void {
-    console.log(modelVersion.id);
     const toRequest = endpoint =>
       this.http
         .get(endpoint, { params: { model_version_id: `${modelVersion.id}` } })

--- a/src/app/modules/model-version/services-support.service.ts
+++ b/src/app/modules/model-version/services-support.service.ts
@@ -9,18 +9,25 @@ export interface ServiceSupported {
   message: string;
   description?: string;
 }
+
+export interface ModelVersionServicesStatus {
+  [serviceName: string]: ServiceSupported
+}
+
 const enum ServicesEndpoints {
   stat = 'stat/support',
   visualization = 'visualization/supported',
 }
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class ServicesSupportService {
-  servicesSupport$: Observable<{ [serviceName: string]: ServiceSupported }>;
+  servicesSupport$: Observable<ModelVersionServicesStatus>;
 
   private servicesSupport: BehaviorSubject<{
     [serviceName: string]: any;
-  }> = new BehaviorSubject<{ [serviceName: string]: ServiceSupported }>({});
+  }> = new BehaviorSubject<ModelVersionServicesStatus>({});
 
   constructor(private http: HttpService) {
     this.servicesSupport$ = this.servicesSupport
@@ -29,6 +36,7 @@ export class ServicesSupportService {
   }
 
   loadSupported(modelVersion: ModelVersion): void {
+    console.log(modelVersion.id);
     const toRequest = endpoint =>
       this.http
         .get(endpoint, { params: { model_version_id: `${modelVersion.id}` } })
@@ -37,12 +45,10 @@ export class ServicesSupportService {
     forkJoin({
       stat: toRequest(ServicesEndpoints.stat),
       visualization: toRequest(ServicesEndpoints.visualization),
-    }).subscribe(res => this.servicesSupport.next(res));
+    }).subscribe(res => {this.servicesSupport.next(res)});
   }
 
-  getServiceSupported(): Observable<{
-    [serviceName: string]: ServiceSupported;
-  }> {
+  getServiceSupported(): Observable<ModelVersionServicesStatus> {
     return this.servicesSupport$;
   }
 


### PR DESCRIPTION
- the ServicesSupportService has been rewritten in such a way that it now loads the statuses of the available services for a specific version of the model and stores them in a state;
- the Services section of Models view has been refactored;
- the availability of checking model version's service has been added to popup on Application's view.