### PR TITLE
fix manager grpc path and remove unused /grpc

### DIFF
--- a/docker/nginx/conf.d/grpc/include.auto_od.template
+++ b/docker/nginx/conf.d/grpc/include.auto_od.template
@@ -1,7 +1,3 @@
 location /hydrosphere.auto_od. {
   grpc_pass grpc://${AUTO_OD_HOST}:${AUTO_OD_GRPC_PORT};
 }
-
-location /grpc/hydrosphere.auto_od. {
-  grpc_pass grpc://${AUTO_OD_HOST}:${AUTO_OD_GRPC_PORT};
-}

--- a/docker/nginx/conf.d/grpc/include.gateway.template
+++ b/docker/nginx/conf.d/grpc/include.gateway.template
@@ -7,13 +7,3 @@ location /hydrosphere.serving.gateway. {
   grpc_pass grpc://$GATEWAY_HOST:$GATEWAY_GRPC_PORT;
   #grpc_pass grpc://gateway_grpc;
 }
-
-location /grpc/tensorflow.serving. {
-  grpc_pass grpc://$GATEWAY_HOST:$GATEWAY_GRPC_PORT;
-  #grpc_pass grpc://gateway_grpc;
-}
-
-location /grpc/hydrosphere.serving.gateway. {
-  grpc_pass grpc://$GATEWAY_HOST:$GATEWAY_GRPC_PORT;
-  #grpc_pass grpc://gateway_grpc;
-}

--- a/docker/nginx/conf.d/grpc/include.manager.template
+++ b/docker/nginx/conf.d/grpc/include.manager.template
@@ -6,6 +6,6 @@ location /hydrosphere.discovery. {
   grpc_pass grpc://${MANAGER_HOST}:${MANAGER_GRPC_PORT};
 }
 
-location /hydrosphere.serving. {
+location /hydrosphere.serving.manager. {
   grpc_pass grpc://${MANAGER_HOST}:${MANAGER_GRPC_PORT};
 }

--- a/docker/nginx/conf.d/grpc/include.manager.template
+++ b/docker/nginx/conf.d/grpc/include.manager.template
@@ -6,10 +6,6 @@ location /hydrosphere.discovery. {
   grpc_pass grpc://${MANAGER_HOST}:${MANAGER_GRPC_PORT};
 }
 
-location /grpc/hydrosphere.manager. {
-  grpc_pass grpc://${MANAGER_HOST}:${MANAGER_GRPC_PORT};
-}
-
-location /grpc/hydrosphere.discovery. {
+location /hydrosphere.serving. {
   grpc_pass grpc://${MANAGER_HOST}:${MANAGER_GRPC_PORT};
 }

--- a/docker/nginx/conf.d/grpc/include.monitoring.template
+++ b/docker/nginx/conf.d/grpc/include.monitoring.template
@@ -1,7 +1,3 @@
 location /hydrosphere.monitoring. {
   grpc_pass grpc://${MONITORING_HOST}:${MONITORING_GRPC_PORT};
 }
-
-location /grpc/hydrosphere.monitoring. {
-  grpc_pass grpc://${MONITORING_HOST}:${MONITORING_GRPC_PORT};
-}

--- a/docker/nginx/conf.d/grpc/include.visualization.template
+++ b/docker/nginx/conf.d/grpc/include.visualization.template
@@ -1,7 +1,3 @@
 location /hydrosphere.visualization. {
   grpc_pass grpc://${VISUALIZATION_HOST}:${VISUALIZATION_GRPC_PORT};
 }
-
-location /grpc/hydrosphere.visualization. {
-  grpc_pass grpc://${VISUALIZATION_HOST}:${VISUALIZATION_GRPC_PORT};
-}

--- a/docker/nginx/conf.d/http.conf
+++ b/docker/nginx/conf.d/http.conf
@@ -1,6 +1,5 @@
 server {
   listen 8080 default_server;
-  server_name _;
 
   client_max_body_size 1G;
   root   /usr/share/nginx/html;


### PR DESCRIPTION
investigating a problem with grpc and loading training data, I found that the request goes to /hydrosphere.serving.manager instead of /hydrosphere.discovery.  Just add location /hydrosphere.serving.manager. to Nginx config