### PR TITLE
Fix the Deployment configs page

### DIFF
--- a/jenkinsfile.groovy
+++ b/jenkinsfile.groovy
@@ -71,17 +71,17 @@ def pushDocker(String registryUrl, String dockerImage){
 def updateDockerCompose(String newVersion){
   dir('docker-compose'){
     //Change template
-    sh script: "sed \"s/.*image:.*/    image: hydrosphere\\/hydro-serving-ui:$newVersion/g\" hydro-serving-ui.service.template > hydro-serving-ui.compose", label: "sed hydro-serving-ui version"
+    sh script: "sed -i \"s/.*image:.*/    image: hydrosphere\\/hydro-serving-ui:$newVersion/g\" hydro-serving-ui.service.template", label: "sed hydro-serving-ui version"
     //Merge compose into 1 file
     composeMerge = "docker-compose"
-    composeService = sh label: "Get all template", returnStdout: true, script: "ls *.compose"
+    composeService = sh label: "Get all template", returnStdout: true, script: "ls *.template"
     list = composeService.split( "\\r?\\n" )
     for(l in list){
         composeMerge = composeMerge + " -f $l"
     }
-    composeMerge = composeMerge + " config > docker-compose.yaml"
+    composeMerge = composeMerge + " config > ../docker-compose.yaml"
     sh script: "$composeMerge", label:"Merge compose file"
-    sh script: "cp docker-compose.yaml ../docker-compose.yaml"
+    //sh script: "cp docker-compose.yaml ../docker-compose.yaml"
   }
 }
 

--- a/src/app/core/data/services/deployment-configs.service.ts
+++ b/src/app/core/data/services/deployment-configs.service.ts
@@ -3,6 +3,7 @@ import { environment } from '@environments/environment';
 
 import { HttpService } from '@app/core/data/services/http.service';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { DeploymentConfig } from '../types';
 
@@ -10,19 +11,27 @@ import { DeploymentConfig } from '../types';
   providedIn: 'root',
 })
 export class DeploymentConfigsService {
-  private readonly baseAPIUrl = `${environment.apiUrl}/deployment_configuration`;
+  private readonly baseAPIUrl: string;
 
-  constructor(private readonly http: HttpService) {}
+  constructor(private http: HttpService) {
+    this.baseAPIUrl = `${environment.apiUrl}/deployment_configuration`;
+  }
 
-  getAll(): Observable<DeploymentConfig[]> {
+  public getAll(): Observable<DeploymentConfig[]> {
     return this.http.get<DeploymentConfig[]>(this.baseAPIUrl);
   }
 
-  get(name: string): Observable<DeploymentConfig> {
+  public get(name: string): Observable<DeploymentConfig> {
     return this.http.get<DeploymentConfig>(`${this.baseAPIUrl}/${name}`);
   }
 
-  delete(name: string): Observable<any> {
+  public addConfig(config: DeploymentConfig) {
+    return this.http
+      .post(this.baseAPIUrl, config)
+      .pipe(map((res: Response): any => res));
+  }
+
+  public delete(name: string): Observable<any> {
     return this.http.delete(`${this.baseAPIUrl}/${name}`);
   }
 }

--- a/src/app/core/facades/deployment-configs.facade.ts
+++ b/src/app/core/facades/deployment-configs.facade.ts
@@ -4,13 +4,13 @@ import { Observable, BehaviorSubject, combineLatest } from 'rxjs';
 import { map, debounceTime } from 'rxjs/internal/operators';
 import { DeploymentConfig } from '../data/types';
 import {
+  AddDeploymentConfig,
   DeleteDeploymentConfig,
   GetDeploymentConfigs,
-  UpdateDeploymentConfig
 } from '../store/actions/deployment-configs.actions';
 import { State } from '../store/states/deployment-configs.state';
 import {
-  selectAllConfigs,
+  selectAllConfigs, selectDepConfigLoaded,
   selectSelectedDeploymentConfig,
 } from '../store/selectors/deployment-configs.selectors';
 
@@ -53,11 +53,15 @@ export class DeploymentConfigsFacade {
     this.store.dispatch(DeleteDeploymentConfig({ name }));
   }
 
-  update(config: DeploymentConfig) {
-    this.store.dispatch(UpdateDeploymentConfig({config}));
+  add(config: DeploymentConfig) {
+    this.store.dispatch(AddDeploymentConfig({ depConfig: config }));
   }
 
   onFilter(filter: string): void {
     this.filterString.next(filter);
+  }
+
+  areDepConfigsLoaded() {
+    return this.store.pipe(select(selectDepConfigLoaded));
   }
 }

--- a/src/app/core/facades/service-statuses.facade.ts
+++ b/src/app/core/facades/service-statuses.facade.ts
@@ -16,7 +16,6 @@ export class ServiceStatusesFacade {
     this.store.dispatch(Get({ payload: modelVersion }));
   }
 
-
   allStatusesEntities() {
     return this.store.pipe(select(allStatusesEntities));
   }

--- a/src/app/core/sse.service.ts
+++ b/src/app/core/sse.service.ts
@@ -57,7 +57,7 @@ export class SseService {
     ],
     [
       SSEEvents.DeploymentConfigurationUpdate,
-      config => this.updateDepConfig(config),
+      config => this.addDepConfig(config),
     ],
     [
       SSEEvents.DeploymentConfigurationRemove,
@@ -117,8 +117,8 @@ export class SseService {
     return fromDepConfigs.DeleteDeploymentConfigSuccess({ name });
   }
 
-  private updateDepConfig(config: DeploymentConfig) {
-    return fromDepConfigs.UpdateDeploymentConfig({ config });
+  private addDepConfig(config: DeploymentConfig) {
+    return fromDepConfigs.AddDeploymentConfigSuccess({ payload: config });
   }
 
   private addEventHandler(item: [string, any]) {

--- a/src/app/core/store/actions/deployment-configs.actions.ts
+++ b/src/app/core/store/actions/deployment-configs.actions.ts
@@ -4,12 +4,10 @@ import { DeploymentConfig } from '../../data/types';
 export const GetDeploymentConfigs = createAction(
   '[Deployment config] get all deployment configs'
 );
-
 export const GetDeploymentConfigsSuccess = createAction(
   '[Deployment config] get all succeed',
-  props<{ configs: DeploymentConfig[] }>()
+  props<{ payload: DeploymentConfig[] }>()
 );
-
 export const GetDeploymentConfigsFail = createAction(
   '[Deployment config] get all failed',
   props<{ error: string }>()
@@ -19,17 +17,25 @@ export const DeleteDeploymentConfig = createAction(
   '[Deployment config] delete',
   props<{ name: string }>()
 );
-
 export const DeleteDeploymentConfigSuccess = createAction(
   '[Deployment config] successful deletion',
   props<{ name: string }>()
 );
-
 export const DeleteDeploymentConfigFail = createAction(
-  '[Deployment config] failed deletion'
+  '[Deployment config] failed deletion',
+  props<{ error: string }>()
 );
 
-export const UpdateDeploymentConfig = createAction(
-  '[Deployment config] update',
-  props<{ config: DeploymentConfig }>()
+export const AddDeploymentConfig = createAction(
+  '[Deployment config] add deployment configuration',
+  props<{ depConfig: DeploymentConfig }>()
 );
+export const AddDeploymentConfigSuccess = createAction(
+  '[Deployment config] add deployment configuration with success',
+  props<{ payload: DeploymentConfig }>()
+);
+export const AddDeploymentConfigFail = createAction(
+  '[Deployment config] add deployment configuration with fail',
+  props<{ error: string }>()
+);
+

--- a/src/app/core/store/reducers/applications.reducer.ts
+++ b/src/app/core/store/reducers/applications.reducer.ts
@@ -22,7 +22,7 @@ const applicationReducer = createReducer(
   initialState,
   on(Get, state => ({ ...state, loading: true })),
   on(GetSuccess, (state, { payload }) =>
-    adapter.addAll(payload, { ...state, loaded: true, loading: false })
+    adapter.setAll(payload, { ...state, loaded: true, loading: false })
   ),
   on(GetFail, state => ({ ...state, loading: false })),
   on(AddSuccess, (state, { payload }) => adapter.addOne(payload, state)),

--- a/src/app/core/store/reducers/deployment-configs.reducer.ts
+++ b/src/app/core/store/reducers/deployment-configs.reducer.ts
@@ -4,30 +4,24 @@ import {
   GetDeploymentConfigs,
   GetDeploymentConfigsSuccess,
   DeleteDeploymentConfigSuccess,
-  UpdateDeploymentConfig
+  GetDeploymentConfigsFail,
+  AddDeploymentConfigSuccess,
 } from '../actions/deployment-configs.actions';
 
-import { State, initialState } from '../states/deployment-configs.state';
+import { State, initialState, adapter } from '../states/deployment-configs.state';
 
 export const deploymentConfigReducer = createReducer(
   initialState,
-  on(GetDeploymentConfigs, state => {
-    return state;
+  on(GetDeploymentConfigs, state => ({ ...state, loading: true })),
+  on(GetDeploymentConfigsSuccess, (state, { payload}) => {
+    return adapter.setAll(payload, {...state, loaded: true, loading: false});
   }),
-  on(GetDeploymentConfigsSuccess, (state, payload) => {
-    return { ...state, configs: payload.configs };
+  on(GetDeploymentConfigsFail, state => ({ ...state, loading: false })),
+  on(DeleteDeploymentConfigSuccess, (state, { name}) => {
+    return adapter.removeOne(name, state);
   }),
-  on(DeleteDeploymentConfigSuccess, (state, payload) => {
-    return {
-      ...state,
-      configs: state.configs.filter(config => config.name !== payload.name),
-    };
-  }),
-  on(UpdateDeploymentConfig, (state, { config }) => {
-    const configs = state.configs;
-    const configExists = configs.some(cfg => cfg.name === config.name);
-
-    return configExists ? state : { ...state, configs: [...configs, config] };
+  on(AddDeploymentConfigSuccess, (state, { payload }) => {
+    return adapter.addOne(payload, state);
   })
 );
 

--- a/src/app/core/store/selectors/deployment-configs.selectors.ts
+++ b/src/app/core/store/selectors/deployment-configs.selectors.ts
@@ -1,15 +1,16 @@
-import { State } from '../states/deployment-configs.state';
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { State, adapter } from '../states/deployment-configs.state';
 import { selectRouterParams } from './router.selectors';
 
-import { createFeatureSelector, createSelector } from '@ngrx/store';
+const state = createFeatureSelector<State>('deploymentConfigs');
 
-const getFeatureState = createFeatureSelector<State>('deploymentConfigs');
+const { selectAll } = adapter.getSelectors();
 
-const configsState = createSelector(getFeatureState, state => state);
+export const selectAllConfigs = createSelector(state, selectAll);
 
-export const selectAllConfigs = createSelector(
-  configsState,
-  state => state.configs
+export const selectDepConfigLoaded = createSelector(
+  state,
+  state => state.loaded
 );
 
 export const selectSelectedDeploymentConfig = createSelector(

--- a/src/app/core/store/states/deployment-configs.state.ts
+++ b/src/app/core/store/states/deployment-configs.state.ts
@@ -1,9 +1,18 @@
+import { EntityState, createEntityAdapter } from '@ngrx/entity';
 import { DeploymentConfig } from '../../data/types';
 
-export interface State {
-  configs: DeploymentConfig[];
+export interface State extends EntityState<DeploymentConfig> {
+  loading: boolean;
+  loaded: boolean;
 }
 
+export const adapter = createEntityAdapter<DeploymentConfig>({
+  selectId: depConfig => depConfig.name,
+});
+
 export const initialState: State = {
-  configs: [],
+  ids: [],
+  entities: {},
+  loading: false,
+  loaded: false,
 };

--- a/src/app/layout/header-nav/header-nav.component.html
+++ b/src/app/layout/header-nav/header-nav.component.html
@@ -20,7 +20,6 @@
   <a
     class="header-nav__item"
     [routerLink]="['/deployment_configs']"
-    skipLocationChange
     routerLinkActive="header-nav__item--active"
   >
     <hydro-icon type="dc" class="header-nav__icon"></hydro-icon>

--- a/src/app/modules/deployment-configs/components/dc-tree/dc-form/dc-form.component.ts
+++ b/src/app/modules/deployment-configs/components/dc-tree/dc-form/dc-form.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { DeploymentConfigsFacade } from '@app/core/facades/deployment-configs.facade';
-import {PreserveFormService} from './preserve-form.service';
 import { Router } from '@angular/router';
-import { DeploymentConfig } from '@app/core/data/types';
+import { DeploymentConfigsFacade } from '@app/core/facades/deployment-configs.facade';
+import { PreserveFormService } from './preserve-form.service';
 
 @Component({
   selector: 'hs-dc-form',
@@ -18,7 +17,7 @@ export class DcFormComponent implements OnInit {
     private readonly facade: DeploymentConfigsFacade,
     private router: Router,
     private formPreserver: PreserveFormService
-  ) { }
+  ) {}
 
   ngOnInit(): void {
     this.form = this.formPreserver.retrieveForm() ? this.formPreserver.retrieveForm() : this.formPreserver.defaultForm();
@@ -39,7 +38,7 @@ export class DcFormComponent implements OnInit {
 
   onSave() {
     let value = this.formPreserver.parseDC(this.form);
-    this.facade.update(value);
+    this.facade.add(value);
     this.formPreserver.clearForm();
     this.router.navigate([`deployment_configs/${value.name}`]);
   }

--- a/src/app/modules/deployment-configs/components/dc-tree/dc-form/preserve-form.service.ts
+++ b/src/app/modules/deployment-configs/components/dc-tree/dc-form/preserve-form.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import {load as loadYaml}  from 'js-yaml' ;
+import { load as loadYaml }  from 'js-yaml' ;
 import { DeploymentConfig } from '@app/core/data/types';
 
 @Injectable({

--- a/src/app/modules/deployment-configs/containers/deployment-config-details/deployment-config-details.component.html
+++ b/src/app/modules/deployment-configs/containers/deployment-config-details/deployment-config-details.component.html
@@ -4,7 +4,7 @@
     kind="flat"
     color="warning"
     class="deployment-config__buttons"
-    (click)="onDelete(config.name)"
+    (click)="removeConfig(config)"
   >
     delete
   </button>

--- a/src/app/modules/deployment-configs/containers/deployment-config-details/deployment-config-details.component.ts
+++ b/src/app/modules/deployment-configs/containers/deployment-config-details/deployment-config-details.component.ts
@@ -2,7 +2,11 @@ import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { DeploymentConfigsFacade } from '@app/core/facades/deployment-configs.facade';
 import { DeploymentConfig } from '@app/core/data/types';
-import { tap } from 'rxjs/operators';
+import { DialogsService } from '@app/modules/dialogs/dialogs.service';
+import {
+  DEPLOYMENT_CONFIG_TOKEN,
+  DialogDeleteDeploymentConfigComponent,
+} from '@app/modules/dialogs/components';
 
 @Component({
   selector: 'hs-deployment-config-details',
@@ -12,10 +16,20 @@ import { tap } from 'rxjs/operators';
 export class DeploymentConfigDetailsComponent implements OnInit {
   config$: Observable<DeploymentConfig>;
   editMode: boolean;
-  constructor(private readonly facade: DeploymentConfigsFacade) {}
+  constructor(
+    private readonly facade: DeploymentConfigsFacade,
+    private readonly dialog: DialogsService
+  ) {}
 
   ngOnInit() {
     this.config$ = this.facade.selectedConfig();
+  }
+
+  removeConfig(config: DeploymentConfig) {
+    this.dialog.createDialog({
+      component: DialogDeleteDeploymentConfigComponent,
+      providers: [{ provide: DEPLOYMENT_CONFIG_TOKEN, useValue: config }],
+    });
   }
 
   onDelete(name: string) {

--- a/src/app/modules/deployment-configs/deployment-configs-routing.module.ts
+++ b/src/app/modules/deployment-configs/deployment-configs-routing.module.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { DeploymentConfigDetailsComponent } from './containers';
 import { DeploymentConfigsPageComponent } from './pages';
 import {DcFormComponent} from './components/dc-tree/dc-form/dc-form.component'
+import { CanActivateDeploymentConfigGuard } from '@app/modules/deployment-configs/guards/can-activate-depconfig.guard';
 @NgModule({
   imports: [
     RouterModule.forChild([
@@ -18,6 +19,7 @@ import {DcFormComponent} from './components/dc-tree/dc-form/dc-form.component'
           {
             path: ':name',
             component: DeploymentConfigDetailsComponent,
+            canActivate: [CanActivateDeploymentConfigGuard]
           },
         ],
 

--- a/src/app/modules/deployment-configs/guards/can-activate-depconfig.guard.ts
+++ b/src/app/modules/deployment-configs/guards/can-activate-depconfig.guard.ts
@@ -1,0 +1,50 @@
+import { MdlSnackbarService } from '@angular-mdl/core';
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Router, CanActivate } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { switchMap, first } from 'rxjs/operators';
+import { DeploymentConfigsFacade } from '@app/core/facades/deployment-configs.facade';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CanActivateDeploymentConfigGuard implements CanActivate {
+  constructor(
+    private facade: DeploymentConfigsFacade,
+    private router: Router,
+    public mdlSnackbarService: MdlSnackbarService
+  ) {}
+
+  canActivate(routerSnapshot: ActivatedRouteSnapshot): Observable<boolean> {
+    return this.loaded().pipe(
+      switchMap(() => this.facade.getAll()),
+      switchMap(depconfigs => {
+        const depConfigName = routerSnapshot.params.name;
+        const depConfigExist = depconfigs.some(({ name }) => name === depConfigName);
+
+        if (depConfigExist) {
+          return of(true);
+        } else {
+          this.showMessage(depConfigName);
+          this.redirect();
+          return of(false);
+        }
+      })
+    );
+  }
+
+  private redirect(): void {
+    this.router.navigate(['/deployment_configs']);
+  }
+
+  private showMessage(name: string): void {
+    this.mdlSnackbarService.showSnackbar({
+      message: `Deployment config with name: ${name} doesn't exist`,
+      timeout: 5000,
+    });
+  }
+
+  private loaded(): Observable<boolean> {
+    return this.facade.areDepConfigsLoaded().pipe(first(loaded => loaded));
+  }
+}

--- a/src/app/modules/deployment-configs/pages/deployment-configs-page/deployment-configs-page.component.html
+++ b/src/app/modules/deployment-configs/pages/deployment-configs-page/deployment-configs-page.component.html
@@ -1,5 +1,5 @@
 <div class="deployment-config-page">
-  <div class="deployment-config-page__sidebar" hsHideInZenMode>
+  <div class="deployment-config-page__sidebar">
     <hs-sidebar
       [sidebarData]="configs$ | async"
       [selectedItem]="selectedConfig$ | async"
@@ -19,20 +19,21 @@
     </hs-sidebar>
   </div>
   <div class="deployment-config-page__body" *ngIf="configs$ | async as configs">
-    <ng-container *ngIf="configs && configs.length; else notify">
+    <ng-container *ngIf="configs && configs.length || toggle; else notify">
       <router-outlet></router-outlet>
     </ng-container>
   </div>
+
+  <ng-template #notify>
+    <div class="deployment-config-page__message">
+      <a
+        class="deployment-config-page__message-link"
+        href="https://docs.hydrosphere.io/quickstart/tutorials/deployment-configuration"
+        target="_blank"
+      >Upload</a
+      >
+      first deployment config
+    </div>
+  </ng-template>
 </div>
 
-<ng-template #notify>
-  <div class="deployment-config-page__message">
-    <a
-      class="deployment-config-page__message-link"
-      href="https://docs.hydrosphere.io/quickstart/tutorials/deployment-configuration"
-      target="_blank"
-      >Upload</a
-    >
-    first deployment config
-  </div>
-</ng-template>

--- a/src/app/modules/deployment-configs/pages/deployment-configs-page/deployment-configs-page.component.ts
+++ b/src/app/modules/deployment-configs/pages/deployment-configs-page/deployment-configs-page.component.ts
@@ -3,6 +3,7 @@ import { Router, Event, NavigationEnd } from '@angular/router';
 
 import { Observable, Subject, Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
+import { first } from 'rxjs/internal/operators';
 
 import { DeploymentConfig } from '@app/core/data/types';
 import { DeploymentConfigsFacade } from '@app/core/facades/deployment-configs.facade';
@@ -20,10 +21,11 @@ export class DeploymentConfigsPageComponent implements OnDestroy {
   private all$: Observable<DeploymentConfig[]>;
   private error: Subject<string> = new Subject<string>();
   private routerSub: Subscription;
+  private toggle: boolean;
 
   constructor(
     private readonly facade: DeploymentConfigsFacade,
-    private readonly router: Router
+    private readonly router: Router,
   ) {
     this.error$ = this.error.asObservable();
 
@@ -35,17 +37,21 @@ export class DeploymentConfigsPageComponent implements OnDestroy {
     this.routerSub = this.router.events
       .pipe(
         filter(event => this.isRootUrl(event)),
-        tap(() => this.redirectToFirst())
+        tap(_ => this.redirectToFirst())
       )
       .subscribe();
+
+    this.toggle = false;
   }
 
   addDeploymentConfig(): void {
+    this.toggle = true;
     this.router.navigate([`deployment_configs/create`]);
   }
 
   ngOnDestroy() {
     this.routerSub.unsubscribe();
+    this.toggle = false;
   }
 
   handleSidebarClick(config: DeploymentConfig): void {
@@ -57,7 +63,7 @@ export class DeploymentConfigsPageComponent implements OnDestroy {
   }
 
   private redirectToFirst() {
-    this.all$.pipe(filter(configs => configs.length > 0)).subscribe(configs => {
+    this.all$.pipe(first(configs => configs.length > 0)).subscribe(configs => {
       this.router.navigate([`deployment_configs/${configs[0].name}`]);
     });
   }

--- a/src/app/modules/dialogs/components/dialog-delete-deployment-config/dialog-delete-deployment-config.component.html
+++ b/src/app/modules/dialogs/components/dialog-delete-deployment-config/dialog-delete-deployment-config.component.html
@@ -1,13 +1,17 @@
 <div class="dialog__content">
-  <span class="dialog__content--question">Remove servable?</span>
-  <div class="dialog__text">
-    {{ servableName }}
-  </div>
+  <span class="dialog__content--question">Remove deployment config?</span>
+  <p class="dialog__text dialog__text--is-alert">{{ name }}</p>
   <div class="dialog__buttons dialog__buttons--column">
-    <button hs-button (click)="onClose()">
+    <button hs-button (click)="dialog.closeDialog()">
       cancel
     </button>
-    <button hs-button kind="flat" color="warning" (click)="onDelete()">
+    <button
+      hs-button
+      kind="flat"
+      color="warning"
+      (click)="onDelete()"
+      hsAutofocused
+    >
       Remove
     </button>
   </div>

--- a/src/app/modules/dialogs/components/dialog-delete-deployment-config/dialog-delete-deployment-config.component.ts
+++ b/src/app/modules/dialogs/components/dialog-delete-deployment-config/dialog-delete-deployment-config.component.ts
@@ -1,5 +1,8 @@
 import { Component, InjectionToken, Inject } from '@angular/core';
+
 import { DeploymentConfigsFacade } from '@app/core/facades/deployment-configs.facade';
+import { DeploymentConfig } from '@app/core/data/types';
+
 import { DialogsService } from '../../dialogs.service';
 
 export const DEPLOYMENT_CONFIG_TOKEN = new InjectionToken(
@@ -11,24 +14,19 @@ export const DEPLOYMENT_CONFIG_TOKEN = new InjectionToken(
   styleUrls: ['./dialog-delete-deployment-config.component.scss'],
 })
 export class DialogDeleteDeploymentConfigComponent {
-  _name: string;
-  constructor(
-    private readonly dialogService: DialogsService,
-    private facade: DeploymentConfigsFacade,
-    @Inject(DEPLOYMENT_CONFIG_TOKEN) name: string
-  ) {
-    this._name = name;
+  get name(): string {
+    return this.config.name;
   }
 
-  get servableName() {
-    return this._name;
-  }
+  constructor(
+    public dialog: DialogsService,
+    private facade: DeploymentConfigsFacade,
+    @Inject(DEPLOYMENT_CONFIG_TOKEN)
+    private config: DeploymentConfig
+  ) {}
 
   onDelete() {
-    this.facade.delete(this._name);
-    this.onClose();
-  }
-  onClose() {
-    this.dialogService.closeDialog();
+    this.facade.delete(this.config.name);
+    this.dialog.closeDialog();
   }
 }

--- a/src/app/shared/components/sidebar/sidebar.component.html
+++ b/src/app/shared/components/sidebar/sidebar.component.html
@@ -20,7 +20,7 @@
         *ngFor="let item of sidebarData"
         (click)="handleClick(item)"
         [ngClass]="{
-          'sidebar__item--selected': selectedItem.name === item.name
+          'sidebar__item--selected': selectedItem ? selectedItem.name === item.name : null
         }"
       >
         <hydro-icon


### PR DESCRIPTION
- "Create Config" button works when list of deployment configs is empty;
- Adding and removing the deployment config now work correctly;
- If backend returns error, snackbar with error message is shown;
- Added guard to deployment's page, when url has wrong deployment's name guard redirects to first element or shows empty page.